### PR TITLE
remove layout definition

### DIFF
--- a/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
+++ b/app/code/Magento/PageBuilder/view/frontend/page_layout/catalog_category_view.xml
@@ -5,7 +5,7 @@
  * See COPYING.txt for license details.
  */
 -->
-<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" layout="2columns-left" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
+<page xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="urn:magento:framework:View/Layout/etc/page_configuration.xsd">
     <body>
         <referenceContainer name="category.view.container">
             <referenceBlock name="category.description" template="Magento_PageBuilder::catalog/category/view/description.phtml"/>


### PR DESCRIPTION
fixes #537


### Description (*)

This PR removes the layout definition from Magento\PageBuilder module in category view pages, since it's already defined in Magento\Catalog module, and due to layouts loading order it breaks the ability to apply a custom layout type from a category edit page in backou

### Bug
<!--- 
* [537](https://github.com/magento/magento2-page-builder/issues/537>) 
-->


### Fixed Issues (if relevant)

1. magento/magento2-page-builder#537: Layout shouldn't be set in a page_layout xml file.

### Manual testing scenarios (*)

1. Install Magento\PageBuilder y a M2.4.3 fresh instance
2. Go to Catalog -> Categories
2. Edit one category
3. Apply a custom layout type in Design Section
4. Layout type is not applied to front page category


### Checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages
 - [ ] All new or changed code is covered with unit/integration tests (if applicable)
 - [ ] README.md files for modified modules are updated and included in the pull request if any [README.md predefined sections](https://github.com/magento/devdocs/wiki/Magento-module-README.md) require an update
 - [ ] All automated tests passed successfully (all builds are green)
